### PR TITLE
Binary path resolves ${eclipse_home} macro and few other small changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+sudo: false
+script: cd com.googlecode.cppcheclipse.parent && mvn clean verify

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 cppcheclipse is an Eclipse plugin which integrates [cppcheck](http://sourceforge.net/projects/cppcheck/) with the [CDT project](https://eclipse.org/cdt/). You can run/configure cppcheck from the Eclipse UI.
 
-To build the project by hand it requires maven and Linux platform (maven under Windows will not compile the project properly). To compile run following commands:
+To build the project on the command line it requires maven and Linux platform (maven under Windows will not compile the project properly). To compile run following commands:
 ```bash
 cd com.googlecode.cppcheclipse.parent
 mvn clean verify
-ls ../com.googlecode.cppcheclipse.repository/target/*.zip -l
 ```
-It will not increment the version number, will not create a relese nor deploy/publish the artifact.
+It will not increment the version number nor deploy/publish/release the artifact. You can find the built p2 repository now in ../com.googlecode.cppcheclipse.repository/target in zip format.
+
 
 Further information on how to use and install cppcheclipse can be found in the [wiki](https://github.com/kwin/cppcheclipse/wiki).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 cppcheclipse is an Eclipse plugin which integrates [cppcheck](http://sourceforge.net/projects/cppcheck/) with the [CDT project](https://eclipse.org/cdt/). You can run/configure cppcheck from the Eclipse UI.
 
+To build the project by hand it requires maven and Linux platform (maven under Windows will not compile the project properly). To compile run following commands:
+```bash
+cd com.googlecode.cppcheclipse.parent
+mvn clean verify
+ls ../com.googlecode.cppcheclipse.repository/target/*.zip -l
+```
+It will not increment the version number, will not create a relese nor deploy/publish the artifact.
+
 Further information on how to use and install cppcheclipse can be found in the [wiki](https://github.com/kwin/cppcheclipse/wiki).

--- a/README.md
+++ b/README.md
@@ -1,11 +1,16 @@
 cppcheclipse is an Eclipse plugin which integrates [cppcheck](http://sourceforge.net/projects/cppcheck/) with the [CDT project](https://eclipse.org/cdt/). You can run/configure cppcheck from the Eclipse UI.
 
-To build the project on the command line it requires maven and Linux platform (maven under Windows will not compile the project properly). To compile run following commands:
+To build the project on the command line it requires maven, Run the following commands:
 ```bash
 cd com.googlecode.cppcheclipse.parent
 mvn clean verify
 ```
 It will not increment the version number nor deploy/publish/release the artifact. You can find the built p2 repository now in ../com.googlecode.cppcheclipse.repository/target in zip format.
+
+**NOTES:**
+
+* Under Windows the `mvn clean verify` will fail because the unit test paths in unix format. As workaround skip the tests `mvn clean` should build successfully.
+* Maven build will fail if Java 9 is used, while it will work under Java 8.
 
 
 Further information on how to use and install cppcheclipse can be found in the [wiki](https://github.com/kwin/cppcheclipse/wiki).

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ It will not increment the version number nor deploy/publish/release the artifact
 
 **NOTES:**
 
-* Under Windows the `mvn clean verify` will fail because the unit test paths in unix format. As workaround skip the tests `mvn clean` should build successfully.
+* Under Windows the `mvn clean verify` will fail because the unit test paths in unix format. As workaround skip the tests `mvn clean package` should build successfully, but it will not create.
 * Maven build will fail if Java 9 is used, while it will work under Java 8.
 
 

--- a/com.googlecode.cppcheclipse.core/META-INF/MANIFEST.MF
+++ b/com.googlecode.cppcheclipse.core/META-INF/MANIFEST.MF
@@ -11,7 +11,8 @@ Require-Bundle: org.eclipse.core.runtime;bundle-version="3.5.0",
  com.google.guava;bundle-version="12.0.0",
  org.apache.commons.codec;bundle-version="1.4.0",
  org.apache.commons.io;bundle-version="2.0.1",
- org.apache.commons.exec;bundle-version="1.1.0"
+ org.apache.commons.exec;bundle-version="1.1.0",
+ org.eclipse.core.variables
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Export-Package: com.googlecode.cppcheclipse.core,

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/Checker.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/Checker.java
@@ -74,7 +74,7 @@ public class Checker {
 			symbols = new Symbols();
 		}
 		
-		String binaryPath = PathMacroReplacer.process(CppcheclipsePlugin.getConfigurationPreferenceStore()
+		String binaryPath = PathMacroReplacer.performMacroSubstitution(CppcheclipsePlugin.getConfigurationPreferenceStore()
 		.getString(IPreferenceConstants.P_BINARY_PATH));
 		
 		command = new CppcheckCommand(console, binaryPath, settingsPreferences,

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/Checker.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/Checker.java
@@ -17,6 +17,7 @@ import org.xml.sax.SAXException;
 
 import com.googlecode.cppcheclipse.core.command.CppcheckCommand;
 import com.googlecode.cppcheclipse.core.command.ProcessExecutionException;
+import com.googlecode.cppcheclipse.core.utils.PathMacroReplacer;
 
 /**
  * This class should abstract from the eclipse concepts for easier testability.
@@ -73,9 +74,8 @@ public class Checker {
 			symbols = new Symbols();
 		}
 		
-		String binaryPath = CppcheclipsePlugin.getConfigurationPreferenceStore()
-		.getString(IPreferenceConstants.P_BINARY_PATH)
-		.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
+		String binaryPath = PathMacroReplacer.process(CppcheclipsePlugin.getConfigurationPreferenceStore()
+		.getString(IPreferenceConstants.P_BINARY_PATH));
 		
 		command = new CppcheckCommand(console, binaryPath, settingsPreferences,
 				projectPreferences, toolchainSettings.getUserIncludes(), toolchainSettings.getSystemIncludes(), symbols);

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/Checker.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/Checker.java
@@ -74,7 +74,8 @@ public class Checker {
 		}
 		
 		String binaryPath = CppcheclipsePlugin.getConfigurationPreferenceStore()
-		.getString(IPreferenceConstants.P_BINARY_PATH);
+		.getString(IPreferenceConstants.P_BINARY_PATH)
+		.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
 		
 		command = new CppcheckCommand(console, binaryPath, settingsPreferences,
 				projectPreferences, toolchainSettings.getUserIncludes(), toolchainSettings.getSystemIncludes(), symbols);

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/CppcheclipsePlugin.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/CppcheclipsePlugin.java
@@ -26,6 +26,7 @@ import org.xml.sax.SAXException;
 
 import com.googlecode.cppcheclipse.core.command.ProcessExecutionException;
 import com.googlecode.cppcheclipse.core.utils.IHttpClientService;
+import com.googlecode.cppcheclipse.core.utils.PathMacroReplacer;
 
 /**
  * The activator class controls the plug-in life cycle
@@ -156,9 +157,8 @@ public class CppcheclipsePlugin extends AbstractUIPlugin implements IPropertyCha
 	
 	private synchronized ProblemProfile getInternalNewProblemProfile(IConsole console, IPreferenceStore store) throws CloneNotSupportedException, XPathExpressionException, IOException, InterruptedException, ParserConfigurationException, SAXException, ProcessExecutionException {
 		if (profile == null) {
-			String binaryPath = CppcheclipsePlugin.getConfigurationPreferenceStore()
-			.getString(IPreferenceConstants.P_BINARY_PATH)
-			.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
+			String binaryPath = PathMacroReplacer.process(CppcheclipsePlugin.getConfigurationPreferenceStore()
+			.getString(IPreferenceConstants.P_BINARY_PATH));
 			profile = new ProblemProfile(console, binaryPath);
 			registerChangeListener();
 			addChangeListener(profile);

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/CppcheclipsePlugin.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/CppcheclipsePlugin.java
@@ -157,7 +157,8 @@ public class CppcheclipsePlugin extends AbstractUIPlugin implements IPropertyCha
 	private synchronized ProblemProfile getInternalNewProblemProfile(IConsole console, IPreferenceStore store) throws CloneNotSupportedException, XPathExpressionException, IOException, InterruptedException, ParserConfigurationException, SAXException, ProcessExecutionException {
 		if (profile == null) {
 			String binaryPath = CppcheclipsePlugin.getConfigurationPreferenceStore()
-			.getString(IPreferenceConstants.P_BINARY_PATH);
+			.getString(IPreferenceConstants.P_BINARY_PATH)
+			.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
 			profile = new ProblemProfile(console, binaryPath);
 			registerChangeListener();
 			addChangeListener(profile);

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/CppcheclipsePlugin.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/CppcheclipsePlugin.java
@@ -157,7 +157,7 @@ public class CppcheclipsePlugin extends AbstractUIPlugin implements IPropertyCha
 	
 	private synchronized ProblemProfile getInternalNewProblemProfile(IConsole console, IPreferenceStore store) throws CloneNotSupportedException, XPathExpressionException, IOException, InterruptedException, ParserConfigurationException, SAXException, ProcessExecutionException {
 		if (profile == null) {
-			String binaryPath = PathMacroReplacer.process(CppcheclipsePlugin.getConfigurationPreferenceStore()
+			String binaryPath = PathMacroReplacer.performMacroSubstitution(CppcheclipsePlugin.getConfigurationPreferenceStore()
 			.getString(IPreferenceConstants.P_BINARY_PATH));
 			profile = new ProblemProfile(console, binaryPath);
 			registerChangeListener();

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/utils/PathMacroReplacer.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/utils/PathMacroReplacer.java
@@ -1,11 +1,39 @@
 package com.googlecode.cppcheclipse.core.utils;
 
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.variables.IStringVariableManager;
+import org.eclipse.core.variables.VariablesPlugin;
+
+import com.googlecode.cppcheclipse.core.CppcheclipsePlugin;
+
+/**
+ * This util class is helping replace path containing macros into real path.
+ * 
+ * Following macros will resolve to:
+ * ${eclipse_home} to a Eclipse's installation folder.
+ * ${project_loc} to the folder of a active project. 
+ * ${workspace_loc} to the current open workspace.
+ * 
+ * https://help.eclipse.org/luna/index.jsp?topic=%2Forg.eclipse.platform.doc.user%2Fconcepts%2Fcpathvars.htm
+ * 
+ * @author Anton Krug
+ * 
+ */
+
 public class PathMacroReplacer {
 	
-	// TODO implement the VariablesPlugin
-	
-	public static String process(String input) {
-		return input.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
+	public static String performMacroSubstitution(String input) {
+		String ret = input;
+		
+		IStringVariableManager manager = VariablesPlugin.getDefault().getStringVariableManager();
+		try {
+			ret = manager.performStringSubstitution(ret, false);
+		} catch (CoreException e) {
+			// in case of a issue, keep the path as it is and log error
+			CppcheclipsePlugin.logError("Path macro subsitution failed", e); //$NON-NLS-1$
+		}		
+		
+		return ret;
 	}
 
 }

--- a/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/utils/PathMacroReplacer.java
+++ b/com.googlecode.cppcheclipse.core/src/com/googlecode/cppcheclipse/core/utils/PathMacroReplacer.java
@@ -1,0 +1,11 @@
+package com.googlecode.cppcheclipse.core.utils;
+
+public class PathMacroReplacer {
+	
+	// TODO implement the VariablesPlugin
+	
+	public static String process(String input) {
+		return input.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
+	}
+
+}

--- a/com.googlecode.cppcheclipse.ui/META-INF/MANIFEST.MF
+++ b/com.googlecode.cppcheclipse.ui/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.4.0",
  org.eclipse.cdt.core;bundle-version="5.0.0",
  org.eclipse.ui.editors;bundle-version="3.4.0",
  org.eclipse.jface.text;bundle-version="3.4.0",
- org.eclipse.cdt.make.core;bundle-version="5.0.0"
+ org.eclipse.cdt.make.core;bundle-version="5.0.0",
+ org.eclipse.debug.ui
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
 Import-Package: org.eclipse.cdt.core.model,

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/Messages.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/Messages.java
@@ -25,12 +25,16 @@ public class Messages extends NLS {
 	public static String BinaryPathPreferencePage_ButtonSave;
 	public static String BinaryPathPreferencePage_CheckForUpdate;
 	public static String BinaryPathPreferencePage_Description;
+	public static String BinaryPathPreferencePage_FileDialogButton;
+	public static String BinaryPathPreferencePage_FileDialogTitle;
 	public static String BinaryPathPreferencePage_NoValidPath;
 	public static String BinaryPathPreferencePage_PathToBinary;
 	public static String BinaryPathPreferencePage_UnknownVersion;
 	public static String BinaryPathPreferencePage_UpdateCheckNever;
 	public static String BinaryPathPreferencePage_UpdateCheckNotice;
 	public static String BinaryPathPreferencePage_UpdateInterval;
+	public static String BinaryPathPreferencePage_VariablesButton;
+
 	public static String BinaryPathPreferencePage_VersionTooOld;
 	public static String BinaryPathPreferencePage_LinkToCppcheck;
 	public static String Builder_IncrementalBuilderTask;

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/UpdateCheck.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/UpdateCheck.java
@@ -22,6 +22,7 @@ import com.googlecode.cppcheclipse.core.CppcheclipsePlugin;
 import com.googlecode.cppcheclipse.core.IPreferenceConstants;
 import com.googlecode.cppcheclipse.core.command.UpdateCheckCommand;
 import com.googlecode.cppcheclipse.core.command.Version;
+import com.googlecode.cppcheclipse.core.utils.PathMacroReplacer;
 
 public class UpdateCheck {
 	private static final String DATE_PATTERN = "yyyy.MM.dd HH:mm:ss"; //$NON-NLS-1$
@@ -93,9 +94,8 @@ public class UpdateCheck {
 	public static boolean startUpdateCheck() {
 		// do not start another update check, if one is already running
 		if (UpdateCheck.needUpdateCheck()) {
-			String binaryPath = CppcheclipsePlugin.getConfigurationPreferenceStore()
-			.getString(IPreferenceConstants.P_BINARY_PATH)
-			.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
+			String binaryPath = PathMacroReplacer.process(CppcheclipsePlugin.getConfigurationPreferenceStore()
+			.getString(IPreferenceConstants.P_BINARY_PATH));
 			new UpdateCheck(true).check(binaryPath);
 			return true;
 		}

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/UpdateCheck.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/UpdateCheck.java
@@ -94,7 +94,7 @@ public class UpdateCheck {
 	public static boolean startUpdateCheck() {
 		// do not start another update check, if one is already running
 		if (UpdateCheck.needUpdateCheck()) {
-			String binaryPath = PathMacroReplacer.process(CppcheclipsePlugin.getConfigurationPreferenceStore()
+			String binaryPath = PathMacroReplacer.performMacroSubstitution(CppcheclipsePlugin.getConfigurationPreferenceStore()
 			.getString(IPreferenceConstants.P_BINARY_PATH));
 			new UpdateCheck(true).check(binaryPath);
 			return true;

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/UpdateCheck.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/UpdateCheck.java
@@ -94,7 +94,8 @@ public class UpdateCheck {
 		// do not start another update check, if one is already running
 		if (UpdateCheck.needUpdateCheck()) {
 			String binaryPath = CppcheclipsePlugin.getConfigurationPreferenceStore()
-			.getString(IPreferenceConstants.P_BINARY_PATH);
+			.getString(IPreferenceConstants.P_BINARY_PATH)
+			.replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
 			new UpdateCheck(true).check(binaryPath);
 			return true;
 		}

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/marker/CheckDescriptionResolution.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/marker/CheckDescriptionResolution.java
@@ -9,7 +9,7 @@ import com.googlecode.cppcheclipse.ui.Utils;
 
 public class CheckDescriptionResolution implements IMarkerResolution {
 
-	private static final String CHECK_DESCRIPTION_URL = "http://sourceforge.net/apps/mediawiki/cppcheck/index.php?title=Main_Page#Checks"; //$NON-NLS-1$
+	private static final String CHECK_DESCRIPTION_URL = "https://sourceforge.net/p/cppcheck/wiki/Home/#checks"; //$NON-NLS-1$
 	public String getLabel() {
 		return Messages.CheckDescriptionResolution_Label;
 	}

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/messages.properties
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/messages.properties
@@ -19,6 +19,8 @@ BinaryPathPreferencePage_ButtonDiscard=Discard
 BinaryPathPreferencePage_ButtonSave=Save
 BinaryPathPreferencePage_CheckForUpdate=Check for update now...
 BinaryPathPreferencePage_Description=Set path to cppcheck binary and update settings. 
+BinaryPathPreferencePage_FileDialogButton=Browse
+BinaryPathPreferencePage_FileDialogTitle=Location of the cppcheck binary
 BinaryPathPreferencePage_LinkToCppcheck=You must get this binary separately from <a href="http://sourceforge.net/projects/cppcheck/">http://sourceforge.net/projects/cppcheck/</a>.\nGiven cppcheck has version {0}.
 BinaryPathPreferencePage_NoValidPath=No valid path to cppcheck specified!
 BinaryPathPreferencePage_PathToBinary=cppcheck binary path
@@ -26,6 +28,7 @@ BinaryPathPreferencePage_UnknownVersion=??
 BinaryPathPreferencePage_UpdateCheckNever=Never
 BinaryPathPreferencePage_UpdateCheckNotice=This update check only checks for updates to cppcheck. Last update check: {0}\nTo automatically check for updates to cppcheclipse click <A>here</A>.
 BinaryPathPreferencePage_UpdateInterval=How often should the check be run?
+BinaryPathPreferencePage_VariablesButton=Variables
 BinaryPathPreferencePage_VersionTooOld=Version of cppcheck is too old. You need at least version {0} but you only have {1}!
 
 SettingsPreferencePage_CheckAll=Check for all known issues (all)

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
@@ -116,7 +116,9 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 				if (super.checkState()) {
 					// check if it is valid cppcheck binary
 					try {
-						String path = getTextControl().getText();
+						String path = getTextControl().getText()
+						        .replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
+						        
 						VersionCommand versionCommand = new VersionCommand(
 								Console.getInstance(), path);
 						Version version = versionCommand

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
@@ -11,7 +11,7 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.FileFieldEditor;
+import org.eclipse.jface.preference.StringFieldEditor;
 import org.eclipse.jface.preference.IPreferenceNode;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.jface.preference.PreferenceManager;
@@ -56,7 +56,7 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 	private RadioGroupFieldEditor updateInterval;
 	private Composite updateIntervalParent;
 	private BooleanFieldEditor automaticUpdateCheck;
-	private FileFieldEditor binaryPath;
+	private StringFieldEditor binaryPath;
 	private Link updateCheckNotice;
 	private boolean hasBinaryPathChanged;
 	private Link link;
@@ -105,9 +105,9 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 	@Override
 	protected void createFieldEditors() {
 		Composite parent = getFieldEditorParent();
-		binaryPath = new FileFieldEditor(IPreferenceConstants.P_BINARY_PATH,
-				Messages.BinaryPathPreferencePage_PathToBinary, true,
-				FileFieldEditor.VALIDATE_ON_KEY_STROKE, parent) {
+		binaryPath = new StringFieldEditor(IPreferenceConstants.P_BINARY_PATH,
+				Messages.BinaryPathPreferencePage_PathToBinary, -1,
+				StringFieldEditor.VALIDATE_ON_KEY_STROKE, parent) {
 
 			@Override
 			protected boolean checkState() {

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
@@ -227,20 +227,18 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 
 		parent = getFieldEditorParent();
 		beforeControlInsertion(parent);
-		Button updateCheckButton = new Button(parent, SWT.PUSH | SWT.LEFT);
+		Button updateCheckButton = new Button(parent, SWT.PUSH | SWT.LEAD);
 		updateCheckButton
 				.setText(Messages.BinaryPathPreferencePage_CheckForUpdate);
 		updateCheckButton.addSelectionListener(new SelectionAdapter() {
 			public void widgetSelected(SelectionEvent event) {
-				{
-					UpdateCheck check = new UpdateCheck(false);
-					try {
-						Job job = check.check(binaryPath.getStringValue());
-						job.join();
-						setLastUpdateCheckDate();
-					} catch (InterruptedException e) {
-						CppcheclipsePlugin.logInfo("Update check interrupted!", e); //$NON-NLS-1$
-					}
+				UpdateCheck check = new UpdateCheck(false);
+				try {
+					Job job = check.check(binaryPath.getStringValue());
+					job.join();
+					setLastUpdateCheckDate();
+				} catch (InterruptedException e) {
+					CppcheclipsePlugin.logInfo("Update check interrupted!", e); //$NON-NLS-1$
 				}
 			}
 		});

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
@@ -117,7 +117,7 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 				if (super.checkState()) {
 					// check if it is valid cppcheck binary
 					try {
-						String path = PathMacroReplacer.process(getTextControl().getText());					        
+						String path = PathMacroReplacer.performMacroSubstitution(getTextControl().getText());					        
 						VersionCommand versionCommand = new VersionCommand(
 								Console.getInstance(), path);
 						Version version = versionCommand

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
@@ -37,6 +37,7 @@ import com.googlecode.cppcheclipse.core.CppcheclipsePlugin;
 import com.googlecode.cppcheclipse.core.IPreferenceConstants;
 import com.googlecode.cppcheclipse.core.command.Version;
 import com.googlecode.cppcheclipse.core.command.VersionCommand;
+import com.googlecode.cppcheclipse.core.utils.PathMacroReplacer;
 import com.googlecode.cppcheclipse.ui.Console;
 import com.googlecode.cppcheclipse.ui.Messages;
 import com.googlecode.cppcheclipse.ui.UpdateCheck;
@@ -116,9 +117,7 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 				if (super.checkState()) {
 					// check if it is valid cppcheck binary
 					try {
-						String path = getTextControl().getText()
-						        .replace("${eclipse_home}", System.getProperty("eclipse.home.location").replace("file:/", ""));
-						        
+						String path = PathMacroReplacer.process(getTextControl().getText());					        
 						VersionCommand versionCommand = new VersionCommand(
 								Console.getInstance(), path);
 						Version version = versionCommand

--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/preferences/BinaryPathPreferencePage.java
@@ -11,7 +11,8 @@ import org.eclipse.jface.dialogs.IDialogConstants;
 import org.eclipse.jface.dialogs.MessageDialog;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.jface.preference.StringFieldEditor;
+import org.eclipse.jface.preference.StringButtonFieldEditor;
+import org.eclipse.debug.ui.StringVariableSelectionDialog;
 import org.eclipse.jface.preference.IPreferenceNode;
 import org.eclipse.jface.preference.PreferenceDialog;
 import org.eclipse.jface.preference.PreferenceManager;
@@ -31,6 +32,7 @@ import org.eclipse.swt.widgets.Listener;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 import org.eclipse.ui.PlatformUI;
+import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.ui.dialogs.PreferencesUtil;
 
 import com.googlecode.cppcheclipse.core.CppcheclipsePlugin;
@@ -57,7 +59,7 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 	private RadioGroupFieldEditor updateInterval;
 	private Composite updateIntervalParent;
 	private BooleanFieldEditor automaticUpdateCheck;
-	private StringFieldEditor binaryPath;
+	private StringButtonFieldEditor binaryPath;
 	private Link updateCheckNotice;
 	private boolean hasBinaryPathChanged;
 	private Link link;
@@ -106,9 +108,12 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 	@Override
 	protected void createFieldEditors() {
 		Composite parent = getFieldEditorParent();
-		binaryPath = new StringFieldEditor(IPreferenceConstants.P_BINARY_PATH,
-				Messages.BinaryPathPreferencePage_PathToBinary, -1,
-				StringFieldEditor.VALIDATE_ON_KEY_STROKE, parent) {
+		
+		final FileDialog fileDialog = new FileDialog(getShell(), SWT.OPEN);
+		fileDialog.setText(Messages.BinaryPathPreferencePage_FileDialogTitle);
+		
+		binaryPath = new StringButtonFieldEditor(IPreferenceConstants.P_BINARY_PATH,
+				Messages.BinaryPathPreferencePage_PathToBinary, parent) {
 
 			@Override
 			protected boolean checkState() {
@@ -151,11 +156,37 @@ public class BinaryPathPreferencePage extends FieldEditorPreferencePage
 				super.fireValueChanged(property, oldValue, newValue);
 			}
 
+
+
+			@Override
+			protected String changePressed() {
+				// Browse button pressed, after selection finished, it replace the current text
+				return fileDialog.open();
+			}
+
 		};
+		binaryPath.setChangeButtonText(Messages.BinaryPathPreferencePage_FileDialogButton);
 		binaryPath.setEmptyStringAllowed(false);
 		binaryPath
 				.setErrorMessage(Messages.BinaryPathPreferencePage_NoValidPath);
 		addField(binaryPath);
+		
+		final StringVariableSelectionDialog variablesDialog = new StringVariableSelectionDialog(getShell());
+		Button variablesButton = new Button(parent, SWT.PUSH | SWT.TRAIL);
+		variablesButton.setText(Messages.BinaryPathPreferencePage_VariablesButton);
+		variablesButton.addSelectionListener(new SelectionAdapter() {
+			public void widgetSelected(SelectionEvent event) {
+				if (variablesDialog.open() == IDialogConstants.OK_ID) {
+					final String variable = variablesDialog.getVariableExpression();
+					if (variable != null) {
+						// append the selected variable to the end of the path
+						binaryPath.setStringValue(binaryPath.getStringValue() + variable);
+					}
+				}
+			}
+		});
+		
+		afterControlInsertion(variablesButton);
 
 		parent = getFieldEditorParent();
 		beforeControlInsertion(parent);


### PR DESCRIPTION
- File field changed to String field (the browse button is lost, but now it's possible to use custom macros as the path)
- ${eclipse_home} macro will resolve as the installation directory, allowing relative paths. Meaning that portable installations of Eclipse where the cppcheck is bundled with the IDE are possible now.
- "Go to check description" URL was updated
- The readme contains few lines of the script so people can build it quickly by hand.
- travis CI support  