### PR TITLE
Bug fix #80. Fixed issue with URI is not absolute.

### DIFF
--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/ToolchainSettings.java
@@ -25,6 +25,7 @@ import com.googlecode.cppcheclipse.core.CppcheclipsePlugin;
 import com.googlecode.cppcheclipse.core.IToolchainSettings;
 import com.googlecode.cppcheclipse.core.Symbol;
 
+
 /**
  * Getting some settings done in the toolchain of CDT
  * 
@@ -136,7 +137,7 @@ public class ToolchainSettings implements IToolchainSettings {
 			// if we could resolve the file
 			if (files.length > 0) {
 				for (IFile file : files) {
-					result.add(new File(file.getRawLocationURI()));
+					result.add(new File(file.getLocationURI()));
 				}
 			} else {
 				// otherwise just take the whole file


### PR DESCRIPTION
FIxed  bug #80. When include path is pointing to linked resource folder its RAW path contain
PARENT-x-PROJECT_LOC so exception was thrown. Using getLocationURI() instead of getRawLocationURI() fixes this issue.