### PR TITLE
Removed un-used and un-initialized string

### DIFF
--- a/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/Messages.java
+++ b/com.googlecode.cppcheclipse.ui/src/com/googlecode/cppcheclipse/ui/Messages.java
@@ -102,8 +102,7 @@ public class Messages extends NLS {
 	public static String SymbolsPropertyPage_Description;
 
 	public static String SettingsPreferencePage_Inconclusive;
-	public static String SettingsPreferencePage_LanguageStandard;
-
+	
 	public static String SettingsPreferencePage_TargetPlatform;
 
 	public static String SettingsPreferencePage_LanguageStandard_Posix;


### PR DESCRIPTION
Solving the console NLS warning message about uninitialized SettingsPreferencePage_LanguageStandard

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kwin/cppcheclipse/97)
<!-- Reviewable:end -->
